### PR TITLE
Use separate connection with pooling for each function

### DIFF
--- a/Dictionary.csproj
+++ b/Dictionary.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="symspell" Version="6.7.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.106.0" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.106.0" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.7" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ECDict.cs
+++ b/src/ECDict.cs
@@ -11,13 +11,12 @@ namespace Dictionary
 {
     class ECDict
     {
-        readonly SQLiteConnection conn;
+        readonly string connString;
         Regex stripWord = new Regex("[^a-zA-Z0-9]");
 
         public ECDict(string filename)
         {
-            conn = new SQLiteConnection("Data Source=" + filename + ";Version=3;Read Only=True");
-            conn.Open();
+            connString = "Data Source=" + filename + ";Version=3;Read Only=True;Pooling=true;";
         }
 
         public string StripWord(string word)
@@ -34,7 +33,8 @@ namespace Dictionary
             string sql = $"select * from stardict where word = '{word}'";
 
             Word ret = null;
-
+            using var conn = new SQLiteConnection(connString);
+            await conn.OpenAsync(token);
             using SQLiteCommand cmd = new SQLiteCommand(sql, conn);
             using SQLiteDataReader reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false) as SQLiteDataReader;
 
@@ -52,6 +52,8 @@ namespace Dictionary
 
             string sql = $"select * from stardict where word in ('{queryTerms}')";
 
+            using var conn = new SQLiteConnection(connString);
+            await conn.OpenAsync(token);
             using SQLiteCommand cmd = new SQLiteCommand(sql, conn);
             using SQLiteDataReader reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false) as SQLiteDataReader;
 
@@ -68,6 +70,8 @@ namespace Dictionary
             string sql = "select * from stardict where sw like '" + word +
                 "%' order by frq > 0 desc, frq asc limit " + limit;
 
+            using var conn = new SQLiteConnection(connString);
+            await conn.OpenAsync(token);
             using SQLiteCommand cmd = new SQLiteCommand(sql, conn);
             using SQLiteDataReader reader = await cmd.ExecuteReaderAsync(token).ConfigureAwait(false) as SQLiteDataReader;
             while (await reader.ReadAsync(token).ConfigureAwait(false))


### PR DESCRIPTION
QueryRange and QueryLike takes quite a bit of time when query string is short, so one connection is hard to handle them when typing fast.
With this build I can see the result pop out fluently, when I am typing quickly.
On the past, sometimes it takes quite a while to wait until the result pop up for latest query after typing a word.

I believe multiple connection help concurrent reading quite a lot. However, not sure whether it would be better to keep one connection per query or keep one connection per select, but I think using pool will be fine.