### PR TITLE
Automatically create release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore: 
       - .github/workflows/*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+    paths-ignore: 
+      - .github/workflows/*
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.301
+      - name: get version
+        id: version
+        uses: notiz-dev/github-action-json-property@release
+        with: 
+          path: 'plugin.json'
+          prop_path: 'Version'
+      - run: echo ${{steps.version.outputs.prop}} 
+      - name: Build
+        run: |
+          dotnet publish 'Dictionary.csproj' --framework netcoreapp3.1  -c Release -o "Dictionary"
+          7z a -tzip "Dictionary.zip" "Dictionary/*"
+          rm -r "Runner"
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "Dictionary.zip"
+          tag_name: "v${{steps.version.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ release ]
     paths-ignore: 
       - .github/workflows/*
 


### PR DESCRIPTION
I copy this workflow from Wox.Plugin.Runner to create automatically create release, so that any merge to main will automatically creates a release based on the version in plugin.json. 
Flow has added new feature to automatically detect update for plugins, so that means we only need to review and merge change in the future.