### PR TITLE
Fix the exception when calling Process.Start with a URL

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name":"Dictionary",
     "Description":"English dictionary, word correction and synonym.",
     "Author":"Harry Yu",
-    "Version":"2.3.1",
+    "Version":"2.3.2",
     "Language":"csharp",
     "Website":"https://github.com/harrynull/Flow.Launcher.Dictionary",
     "IcoPath":"Images\\plugin.png",

--- a/src/Dictionary.cs
+++ b/src/Dictionary.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Windows.Controls;
 using Flow.Launcher.Plugin;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace Dictionary
 {
@@ -108,7 +109,15 @@ namespace Dictionary
                 {
                     if (CopyIfNeeded(e)) return true;
                     //if(ReadWordIfNeeded(e)) return false;
-                    if (settings.WordWebsite != "") System.Diagnostics.Process.Start(string.Format(settings.WordWebsite, GetWord()));
+                    if (settings.WordWebsite != "") 
+                    {
+                      var ps = new ProcessStartInfo(string.Format(settings.WordWebsite, GetWord())) 
+                      {
+                        UseShellExecute = true,
+                        Verb = "open",
+                      };
+                      System.Diagnostics.Process.Start(ps);
+                    }
                     return true;
                 };
             }

--- a/src/Dictionary.cs
+++ b/src/Dictionary.cs
@@ -11,7 +11,6 @@ using System.Windows;
 using System.Windows.Controls;
 using Flow.Launcher.Plugin;
 using System.Threading.Tasks;
-using System.Diagnostics;
 
 namespace Dictionary
 {
@@ -111,7 +110,7 @@ namespace Dictionary
                     //if(ReadWordIfNeeded(e)) return false;
                     if (settings.WordWebsite != "") 
                     {
-                      var ps = new ProcessStartInfo(string.Format(settings.WordWebsite, GetWord())) 
+                      var ps = new System.Diagnostics.ProcessStartInfo(string.Format(settings.WordWebsite, GetWord())) 
                       {
                         UseShellExecute = true,
                         Verb = "open",


### PR DESCRIPTION
Close #19 .

.NET Core doesn't support invoking `System.Diagnostic.Process.Start(String)` with a URL, as described [in this issue](https://github.com/dotnet/runtime/issues/17938). 

This PR creates a `ProcessStartInfo` instance explicitly and passes it to the `Start` method instead of a plain URL string.